### PR TITLE
Feature/aaduszki crt om

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ find_ups_product( fftw )
 find_ups_product( sbndaq_decode v0_03_00 )
 find_ups_product( sbndaq_online v0_03_00 )
 find_ups_product( sbnobj )
+find_ups_product( icaruscode v09_17_01 )
 # include_directories($ENV{JSONCPP_LIB})
 
 # macros for dictionary and simple_plugin

--- a/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
+++ b/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
@@ -88,7 +88,7 @@ void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   const std::vector<icarus::crt::BernCRTTranslator> hit_vector =  icarus::crt::BernCRTTranslator::getCRTData(evt);
 
   for(auto & hit : hit_vector) {
-    TLOG(TLVL_INFO)<<hit;
+//    TLOG(TLVL_INFO)<<hit;
 
     //data from FEB:
     int mac5     = hit.mac5;

--- a/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
+++ b/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
@@ -21,6 +21,9 @@
 #include "sbndaq-online/helpers/MetricConfig.h"
 //---
 //#include "art/Framework/Services/Optional/TFileService.h"
+
+#include "icaruscode/CRT/CRTDecoder/BernCRTTranslator.hh"
+
 #include "TH1F.h"
 #include "TNtuple.h"
 
@@ -49,8 +52,6 @@ public:
   virtual void analyze(art::Event const & evt);
   
 private:
-  void analyze_fragment(artdaq::Fragment & frag);  
-
   //sample histogram
   TH1F* fSampleHist;
   
@@ -77,111 +78,6 @@ sbndaq::BernCRTdqm::~BernCRTdqm()
 }
 
 
-void sbndaq::BernCRTdqm::analyze_fragment(artdaq::Fragment & frag) {
-
-  BernCRTFragment bern_fragment(frag);
-
-  //gets a pointers to the data and metadata from the fragment
-  BernCRTEvent const* evt = bern_fragment.eventdata();
-//  const BernCRTFragmentMetadata* md = bern_fragment.metadata();
-
-//  std::cout << *evt << std::endl;
-//  std::cout << *md << std::endl;
-
-  //Get information from the fragment
-  //unused variables must be commented, as the compiler treats warnings as errors
-  //header:
-  //    uint64_t fragment_timestamp = frag.timestamp();
-  //    uint64_t fragment_id        = frag.fragmentID();
-
-  //data from FEB:
-  int mac5     = evt->MAC5();
-  unsigned readout_number = mac5;
-  std::string readout_number_str = std::to_string(readout_number);
-
-  //    int flags    = evt->flags;
-  //    int lostcpu  = evt->lostcpu;
-  //    int lostfpga = evt->lostfpga;
-  //    int flags    = evt->flags;
-  //    int lostcpu  = evt->lostcpu;
-  //    int lostfpga = evt->lostfpga;
-  int ts0      = evt->Time_TS0();
-  int ts1      = evt->Time_TS1();
-  //    int coinc    = evt->coinc;
-  bool     isTS0    = evt->IsReference_TS0();
-  bool     isTS1    = evt->IsReference_TS1();
-
-  uint16_t adc[32];
-//  uint16_t rms[32];
-/////  uint16_t& waveform[32];
-
-  for(int ch=0; ch<32; ch++) {
-     adc[ch] = evt->ADC(ch);
-/////     waveform = evt->ADC(ch);
-/////     short baseline = Median(waveform, waveform.size());
-/////     double rms = RMS( waveform, waveform.size(), baseline);
-   }
-  //metadata
-  //    uint64_t run_start_time            = md->run_start_time();
-  //    uint64_t this_poll_start           = md->this_poll_start();
-  //    uint64_t this_poll_end             = md->this_poll_end();
-  //    uint64_t last_poll_start           = md->last_poll_start();
-  //    uint64_t last_poll_end             = md->last_poll_end();
-  //    int32_t  system_clock_deviation    = md->system_clock_deviation();
-  //    uint32_t feb_events_per_poll       = md->feb_events_per_poll();
-  //    uint32_t feb_event_number          = md->feb_event_number();
-
-  //AA: I propose to keep all the code getting fragment data above
-
-
-  size_t max        = 0;
-  size_t totaladc   = 0;
-  size_t ADCchannel = 0;
-
-
-  //    std::string FEBID_str = std::to_string(fragment_id);
-  //    sbndaq::sendMetric("CRT_board", FEBID_str, "FEBID", fragment_id, 0, artdaq::MetricMode::LastPoint); 
-
-
-  //let's fill our sample hist with the Time_TS0()-1e9 if 
-  //it's a GPS reference pulse
-  if(isTS0){
-//    fSampleHist->Fill(ts0 - 1e9); //bug!!! fSampleHist is not defined
-    std::cout<<" TS0 "<<ts0 - 1e9<<std::endl;
-  }
-  if(isTS1){
-//    fSampleHist->Fill(ts1 - 1e9); //bug!!! fSampleHist is not defined
-    std::cout<<" TS1 "<<ts0 - 1e9<<std::endl; 
-  }
-  for(int i = 0; i<32; i++) {
-    totaladc  += adc[i];
-    ADCchannel = adc[i];
-/////    RMSchannel = rms[i];
-    sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "ADC", ADCchannel, 0, artdaq::MetricMode::Average); 
-
-    if(adc[i] > max){
-      max = adc[i];
-    }
-  }
-  int baseline = (totaladc-max)/31;
-  std::cout<<" Maximum ADC value:"<<max<<std::endl;
-  std::cout<<" Average without Max value:"<<baseline<<std::endl;
-  std::cout<<" CRT_board number:" << readout_number_str<<std::endl;
-  sbndaq::sendMetric("CRT_board", readout_number_str, "MaxADCValue", max, 0, artdaq::MetricMode::Average);
-
-  sbndaq::sendMetric("CRT_board", readout_number_str, "baseline", baseline, 0, artdaq::MetricMode::Average);
-
-  //Per board front end metric group
-  sbndaq::sendMetric("CRT_board", readout_number_str, "TS0", ts0, 0, artdaq::MetricMode::LastPoint);
-  sbndaq::sendMetric("CRT_board", readout_number_str, "TS1", ts1, 0, artdaq::MetricMode::LastPoint);
-
-/////////////Other metrics: rms like in PMT stuff
-
-
-  //ADC Analysis metric group
-
-} //analyze_fragment
-
 void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   sleep(2);
 
@@ -189,35 +85,79 @@ void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   std::cout << std::endl;  
   std::cout << "Run " << evt.run() << ", subrun " << evt.subRun()<< ", event " << evt.event();
 
-  //loop over fragments in event
-  //two different loop logics, depending on whether we have fragment containers or fragments
-  std::vector<art::Handle<artdaq::Fragments>> fragmentHandles;
-  evt.getManyByType(fragmentHandles);
-  for (auto handle : fragmentHandles) {
-    if (!handle.isValid() || handle->size() == 0)
-      continue;
+  const std::vector<icarus::crt::BernCRTTranslator> hit_vector =  icarus::crt::BernCRTTranslator::getCRTData(evt);
+
+  for(auto & hit : hit_vector) {
+    TLOG(TLVL_INFO)<<hit;
+
+    //data from FEB:
+    int mac5     = hit.mac5;
+    unsigned readout_number = mac5;
+    std::string readout_number_str = std::to_string(readout_number);
+
+    int ts0      = hit.ts0; 
+    int ts1      = hit.ts1; 
+    bool     isTS0    = hit.IsReference_TS0();
+    bool     isTS1    = hit.IsReference_TS1();
+
+    uint16_t adc[32];
+    //  uint16_t rms[32];
+    /////  uint16_t& waveform[32];
+
+    for(int ch=0; ch<32; ch++) {
+      adc[ch] = hit.adc[ch];
+      /////     waveform = evt->ADC(ch);
+      /////     short baseline = Median(waveform, waveform.size());
+      /////     double rms = RMS( waveform, waveform.size(), baseline);
+    }
+
+    size_t max        = 0;
+    size_t totaladc   = 0;
+    size_t ADCchannel = 0;
 
 
+    //    std::string FEBID_str = std::to_string(fragment_id);
+    //    sbndaq::sendMetric("CRT_board", FEBID_str, "FEBID", fragment_id, 0, artdaq::MetricMode::LastPoint); 
 
-    if (handle->front().type() == artdaq::Fragment::ContainerFragmentType) {
-      //Container fragment
-      for (auto cont : *handle) {
-        artdaq::ContainerFragment contf(cont);
-        if (contf.fragment_type() != sbndaq::detail::FragmentType::BERNCRT)
-          continue;
-        std::cout << " has " <<  contf.block_count() << " CRT fragment(s)." << std::endl;
-        for (size_t ii = 0; ii < contf.block_count(); ++ii)
-          analyze_fragment(*contf[ii].get());
+
+    //let's fill our sample hist with the Time_TS0()-1e9 if 
+    //it's a GPS reference pulse
+    if(isTS0){
+      //    fSampleHist->Fill(ts0 - 1e9); //bug!!! fSampleHist is not defined
+      std::cout<<" TS0 "<<ts0 - 1e9<<std::endl;
+    }
+    if(isTS1){
+      //    fSampleHist->Fill(ts1 - 1e9); //bug!!! fSampleHist is not defined
+      std::cout<<" TS1 "<<ts0 - 1e9<<std::endl; 
+    }
+    for(int i = 0; i<32; i++) {
+      totaladc  += adc[i];
+      ADCchannel = adc[i];
+      /////    RMSchannel = rms[i];
+      sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "ADC", ADCchannel, 0, artdaq::MetricMode::Average); 
+
+      if(adc[i] > max){
+        max = adc[i];
       }
     }
-    else {
-      //normal fragment
-      if (handle->front().type() != sbndaq::detail::FragmentType::BERNCRT) continue;
-      std::cout << " has " << handle->size() << " CRT fragment(s)." << std::endl; 
-      for (auto frag : *handle) 
-        analyze_fragment(frag);
-    }
-  }
+    int baseline = (totaladc-max)/31;
+    std::cout<<" Maximum ADC value:"<<max<<std::endl;
+    std::cout<<" Average without Max value:"<<baseline<<std::endl;
+    std::cout<<" CRT_board number:" << readout_number_str<<std::endl;
+    sbndaq::sendMetric("CRT_board", readout_number_str, "MaxADCValue", max, 0, artdaq::MetricMode::Average);
+
+    sbndaq::sendMetric("CRT_board", readout_number_str, "baseline", baseline, 0, artdaq::MetricMode::Average);
+
+    //Per board front end metric group
+    sbndaq::sendMetric("CRT_board", readout_number_str, "TS0", ts0, 0, artdaq::MetricMode::LastPoint);
+    sbndaq::sendMetric("CRT_board", readout_number_str, "TS1", ts1, 0, artdaq::MetricMode::LastPoint);
+
+    /////////////Other metrics: rms like in PMT stuff
+
+
+    //ADC Analysis metric group
+
+  } //loop over hits in event
 } //analyze
 
 

--- a/sbndqm/dqmAnalysis/CRT/CMakeLists.txt
+++ b/sbndqm/dqmAnalysis/CRT/CMakeLists.txt
@@ -7,5 +7,6 @@ simple_plugin( BernCRTdqm module
   sbndaq_online_storage
   sbndaq_online_hiredis
   sbndaqMode
+  BERN_CRT_TRANSLATOR
 )
 


### PR DESCRIPTION
This update makes BernCRTdqm_module.cc use BernCRTTranslator from icaruscode to read the data, and thus (hopefully) solves the issue of present and future compatibility with various versions of data files.

This add icaruscode as a dependency of sbndqm. Maybe in future BernCRTTranslator should reside elsewhere, e.g. in sbncode, but this is a solution we agreed with Wes for now.

Tested on a data file collected in the past.