### PR TITLE
Updated CRT DQM module to use BernCRTTranslator

### DIFF
--- a/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
+++ b/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
@@ -52,7 +52,6 @@ public:
   virtual void analyze(art::Event const & evt);
  
 private:
-  void analyze_fragment(artdaq::Fragment & frag);  
    uint64_t lastbighit[32];
 
   uint16_t silly = 0;
@@ -83,134 +82,6 @@ sbndaq::BernCRTdqm::~BernCRTdqm()
 }
 
 
-void sbndaq::BernCRTdqm::analyze_fragment(artdaq::Fragment & frag) {
-
-  BernCRTFragment bern_fragment(frag);
-
-  //gets a pointers to the data and metadata from the fragment
-  BernCRTEvent const* evt = bern_fragment.eventdata();
-  const BernCRTFragmentMetadata* md = bern_fragment.metadata();
-
-//  std::cout << *evt << std::endl;
-//  std::cout << *md << std::endl;
-
-  //Get information from the fragment
-  //unused variables must be commented, as the compiler treats warnings as errors
-  //header:
-      uint64_t fragment_timestamp = frag.timestamp();
-      uint64_t fragment_id        = frag.fragmentID();
-
-  //data from FEB:
-  int mac5     = evt->MAC5();
-  unsigned readout_number = mac5;
-  std::string readout_number_str = std::to_string(readout_number);
-
-  //    int flags    = evt->flags;
-  //    int lostcpu  = evt->lostcpu;
-  //    int lostfpga = evt->lostfpga;
-  //    int flags    = evt->flags;
-  //    int lostcpu  = evt->lostcpu;
-  //    int lostfpga = evt->lostfpga;
-  int ts0      = evt->Time_TS0();
-  int ts1      = evt->Time_TS1();
-  //    int coinc    = evt->coinc;
-  bool     isTS0    = evt->IsReference_TS0();
-  bool     isTS1    = evt->IsReference_TS1();
-
-  uint16_t adc[32];
-
-  silly++;
-  for(int ch=0; ch<32; ch++) {
-     adc[ch] = evt->ADC(ch);
-     if( adc[ch] > 600 ) {
-       //cout << ts1 << std::endl;
-       //sbndaq::BernCRTdqm::lastbighit[ch] = ts1 - 1e9;
-       //std::cout << "Okay a big hit!";
-       //std::cout << frag.timestamp() << "\n";
-       sbndaq::BernCRTdqm::lastbighit[ch] = frag.timestamp();
-       //std::cout << sbndaq::BernCRTdqm::lastbighit[ch] << "\n";
-
-     }
-   }
-  //metadata
-  //    uint64_t run_start_time            = md->run_start_time();
-//      uint64_t this_poll_start           = md->this_poll_start();
-      uint64_t this_poll_end             = md->this_poll_end();
-      uint64_t last_poll_start           = md->last_poll_start();
-//      uint64_t last_poll_end             = md->last_poll_end();
-  //    int32_t  system_clock_deviation    = md->system_clock_deviation();
-  //    uint32_t feb_events_per_poll       = md->feb_events_per_poll();
-  //    uint32_t feb_event_number          = md->feb_event_number();
-
-  //AA: I propose to keep all the code getting fragment data above
-
-
-  size_t max        = 0;
-  size_t totaladc   = 0;
-  size_t ADCchannel = 0;
-
-
-      std::string FEBID_str = std::to_string(fragment_id);
-      sbndaq::sendMetric("CRT_board", FEBID_str, "FEBID", fragment_id, 0, artdaq::MetricMode::LastPoint); 
-
-
-  //let's fill our sample hist with the Time_TS0()-1e9 if 
-  //it's a GPS reference pulse
-  if(isTS0){
-//    fSampleHist->Fill(ts0 - 1e9); //bug!!! fSampleHist is not defined
-    std::cout<<" TS0 "<<ts0 - 1e9<<std::endl;
-  }
-  if(isTS1){
-//    fSampleHist->Fill(ts1 - 1e9); //bug!!! fSampleHist is not defined
-    std::cout<<" TS1 "<<ts0 - 1e9<<std::endl; 
-  }
-  for(int i = 0; i<32; i++) {
-    totaladc  += adc[i];
-    ADCchannel = adc[i];
-    uint64_t lastbighitchannel = fragment_timestamp -sbndaq::BernCRTdqm::lastbighit[i];
-/////    RMSchannel = rms[i];
-    sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "ADC", ADCchannel, 0, artdaq::MetricMode::Average); 
-    sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "lastbighit", lastbighitchannel, 0, artdaq::MetricMode::Average); 
-
-    if(adc[i] > max){
-      max = adc[i];
-    }
-  }
-  int baseline = (totaladc-max)/31;
-//  std::cout<<" Maximum ADC value:"<<max<<std::endl;
-//  std::cout<<" Average without Max value:"<<baseline<<std::endl;
-//  std::cout<<" CRT_board number:" << readout_number_str<<std::endl;
-//  std::cout<<" TS1: " << ts1 << std::endl;
-//  std::cout<<" TSO: " << ts0 << std::endl;
-//  std::cout<<" last_poll_start   : " << last_poll_start << std::endl;
-//  std::cout<<" fragment_timestamp: " << fragment_timestamp << std::endl;
-//  std::cout<<" this_poll_end     : " << this_poll_end << std::endl;
-//  for(int i = 0; i < 32; i++ ){
-//    std::cout<<" adc " << i << ": " << adc[i];
-//    std::cout<<" lastbighit " << i << ": " << sbndaq::BernCRTdqm::lastbighit[i] << std::endl;
-//
-//  }
-//  std::cout<<" silly: " << silly << std::endl;
-
-  uint64_t earlysynch = last_poll_start - fragment_timestamp;
-  uint64_t latesynch = fragment_timestamp - this_poll_end;
-
-  sbndaq::sendMetric("CRT_board", readout_number_str, "MaxADCValue", max, 0, artdaq::MetricMode::Average);
-
-  sbndaq::sendMetric("CRT_board", readout_number_str, "baseline", baseline, 0, artdaq::MetricMode::Average);
-
-  //Per board front end metric group
-  sbndaq::sendMetric("CRT_board", readout_number_str, "TS0", ts0, 0, artdaq::MetricMode::LastPoint);
-  sbndaq::sendMetric("CRT_board", readout_number_str, "TS1", ts1, 0, artdaq::MetricMode::LastPoint);
-
-  //Sychronization Metrics
-  sbndaq::sendMetric("CRT_board", readout_number_str, "earlysynch", earlysynch, 0, artdaq::MetricMode::Average);
-  sbndaq::sendMetric("CRT_board", readout_number_str, "latesynch", latesynch, 0, artdaq::MetricMode::Average);
-
-
-
-} //analyze_fragment
-
 void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   //sleep(2);
 
@@ -218,36 +89,115 @@ void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   std::cout << std::endl;  
   std::cout << "Run " << evt.run() << ", subrun " << evt.subRun()<< ", event " << evt.event();
 
+  std::vector<icarus::crt::BernCRTTranslator> hit_vector;
 
-  //loop over fragments in event
-  //two different loop logics, depending on whether we have fragment containers or fragments
   auto fragmentHandles = evt.getMany<artdaq::Fragments>();
-  for (auto handle : fragmentHandles) {
+  for (auto  handle : fragmentHandles) {
     if (!handle.isValid() || handle->size() == 0)
       continue;
 
-    if (handle->front().type() == artdaq::Fragment::ContainerFragmentType) {
-      //Container fragment
-      for(int i = 0; i < 32; i++ ){
-        lastbighit[i]=-1;
-      }
-      for (auto cont : *handle) {
-        artdaq::ContainerFragment contf(cont);
-        if (contf.fragment_type() != sbndaq::detail::FragmentType::BERNCRTV2)
-          continue;
-        std::cout << " has " <<  contf.block_count() << " CRT fragment(s)." << std::endl;
-        for (size_t ii = 0; ii < contf.block_count(); ++ii)
-          analyze_fragment(*contf[ii].get());
-      }
-    }
+    auto this_hit_vector = icarus::crt::BernCRTTranslator::getCRTData(*handle);
 
-    else{
-      if (handle->front().type() != sbndaq::detail::FragmentType::BERNCRTV2) continue;
-      std::cout << " has " << handle->size() << " CRT fragment(s)." << std::endl; 
-      for (auto frag : *handle) 
-        analyze_fragment(frag);
-    }
+    hit_vector.insert(hit_vector.end(),this_hit_vector.begin(),this_hit_vector.end());
   }
+
+  //loop over all CRT hits in an event
+  for(const auto & hit : hit_vector) {
+
+    const uint64_t & fragment_timestamp = hit.timestamp;
+    const uint16_t & fragment_id        = hit.fragment_ID;
+
+    //data from FEB:
+    const uint8_t & mac5     = hit.mac5;
+    unsigned readout_number  = mac5;
+    std::string readout_number_str = std::to_string(readout_number);
+
+    const int ts0      = hit.ts0;
+    const int ts1      = hit.ts1;
+    const bool     isTS0    = hit.IsReference_TS0();
+    const bool     isTS1    = hit.IsReference_TS1();
+
+    const uint16_t * adc = hit.adc;
+
+    silly++;
+    for(int ch=0; ch<32; ch++) {
+      if( adc[ch] > 600 ) {
+        //cout << ts1 << std::endl;
+        //sbndaq::BernCRTdqm::lastbighit[ch] = ts1 - 1e9;
+        //std::cout << "Okay a big hit!";
+        //std::cout << frag.timestamp() << "\n";
+        sbndaq::BernCRTdqm::lastbighit[ch] = fragment_timestamp;
+        //std::cout << sbndaq::BernCRTdqm::lastbighit[ch] << "\n";
+
+      }
+    }
+    const uint64_t & this_poll_end             = hit.this_poll_end;
+    const uint64_t & last_poll_start           = hit.last_poll_start;
+
+    size_t max        = 0;
+    size_t totaladc   = 0;
+    size_t ADCchannel = 0;
+
+
+    std::string FEBID_str = std::to_string(fragment_id);
+    sbndaq::sendMetric("CRT_board", FEBID_str, "FEBID", fragment_id, 0, artdaq::MetricMode::LastPoint); 
+
+
+    //let's fill our sample hist with the Time_TS0()-1e9 if 
+    //it's a GPS reference pulse
+    if(isTS0){
+      //    fSampleHist->Fill(ts0 - 1e9); //bug!!! fSampleHist is not defined
+      std::cout<<" TS0 "<<ts0 - 1e9<<std::endl;
+    }
+    if(isTS1){
+      //    fSampleHist->Fill(ts1 - 1e9); //bug!!! fSampleHist is not defined
+      std::cout<<" TS1 "<<ts0 - 1e9<<std::endl; 
+    }
+    for(int i = 0; i<32; i++) {
+      totaladc  += adc[i];
+      ADCchannel = adc[i];
+      uint64_t lastbighitchannel = fragment_timestamp -sbndaq::BernCRTdqm::lastbighit[i];
+      /////    RMSchannel = rms[i];
+      sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "ADC", ADCchannel, 0, artdaq::MetricMode::Average); 
+      sbndaq::sendMetric("CRT_channel", std::to_string(i + 32 * mac5), "lastbighit", lastbighitchannel, 0, artdaq::MetricMode::Average); 
+
+      if(adc[i] > max){
+        max = adc[i];
+      }
+    }
+    int baseline = (totaladc-max)/31;
+    //  std::cout<<" Maximum ADC value:"<<max<<std::endl;
+    //  std::cout<<" Average without Max value:"<<baseline<<std::endl;
+    //  std::cout<<" CRT_board number:" << readout_number_str<<std::endl;
+    //  std::cout<<" TS1: " << ts1 << std::endl;
+    //  std::cout<<" TSO: " << ts0 << std::endl;
+    //  std::cout<<" last_poll_start   : " << last_poll_start << std::endl;
+    //  std::cout<<" fragment_timestamp: " << fragment_timestamp << std::endl;
+    //  std::cout<<" this_poll_end     : " << this_poll_end << std::endl;
+    //  for(int i = 0; i < 32; i++ ){
+    //    std::cout<<" adc " << i << ": " << adc[i];
+    //    std::cout<<" lastbighit " << i << ": " << sbndaq::BernCRTdqm::lastbighit[i] << std::endl;
+    //
+    //  }
+    //  std::cout<<" silly: " << silly << std::endl;
+
+    uint64_t earlysynch = last_poll_start - fragment_timestamp;
+    uint64_t latesynch = fragment_timestamp - this_poll_end;
+
+    sbndaq::sendMetric("CRT_board", readout_number_str, "MaxADCValue", max, 0, artdaq::MetricMode::Average);
+
+    sbndaq::sendMetric("CRT_board", readout_number_str, "baseline", baseline, 0, artdaq::MetricMode::Average);
+
+    //Per board front end metric group
+    sbndaq::sendMetric("CRT_board", readout_number_str, "TS0", ts0, 0, artdaq::MetricMode::LastPoint);
+    sbndaq::sendMetric("CRT_board", readout_number_str, "TS1", ts1, 0, artdaq::MetricMode::LastPoint);
+
+    //Sychronization Metrics
+    sbndaq::sendMetric("CRT_board", readout_number_str, "earlysynch", earlysynch, 0, artdaq::MetricMode::Average);
+    sbndaq::sendMetric("CRT_board", readout_number_str, "latesynch", latesynch, 0, artdaq::MetricMode::Average);
+
+  } //loop over all CRT hits in an event
+
 } //analyze
 
 

--- a/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
+++ b/sbndqm/dqmAnalysis/CRT/BernCRTdqm_module.cc
@@ -52,6 +52,8 @@ public:
   virtual void analyze(art::Event const & evt);
  
 private:
+  bool IsSideCRT(const icarus::crt::BernCRTTranslator & hit);
+
    uint64_t lastbighit[32];
 
   uint16_t silly = 0;
@@ -81,6 +83,13 @@ sbndaq::BernCRTdqm::~BernCRTdqm()
 {
 }
 
+bool sbndaq::BernCRTdqm::IsSideCRT(const icarus::crt::BernCRTTranslator & hit) {
+  /**
+   * Fragment ID described in SBN doc 16111
+   */
+  return (hit.fragment_ID & 0x3100) == 0x3100;
+}
+
 
 void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   //sleep(2);
@@ -104,8 +113,21 @@ void sbndaq::BernCRTdqm::analyze(art::Event const & evt) {
   //loop over all CRT hits in an event
   for(const auto & hit : hit_vector) {
 
-    const uint64_t & fragment_timestamp = hit.timestamp;
+    enum Detector {SIDE_CRT, TOP_CRT};
+//    const Detector detector = IsSideCRT(hit) ? SIDE_CRT : TOP_CRT;
     const uint16_t & fragment_id        = hit.fragment_ID;
+    /**
+     * TODO:
+     * In order to distinguish between Top and Side CRT
+     * use the variable detector, defined above
+     * Otherwise, MAC address alone is not sufficient,
+     * as some MACs overlap between Top and Side
+     *
+     * Alternative: use fragment_ID directly (fragment_IDs
+     * are unique)
+     */
+
+    const uint64_t & fragment_timestamp = hit.timestamp;
 
     //data from FEB:
     const uint8_t & mac5     = hit.mac5;


### PR DESCRIPTION
1. The code does not compile, because the newest changes from sbndaq_artdaq_core v1_00_00of2 are not yet available
2. The logic of sending the metrics need to be identified. With Top CRT using the same MAC addresses as Side CRT one cannot identify the FEBs using MAC5. Fragment ID should be used instead. The code to read fragment ID is included, but one needs to propagate it through the rest of the OM logic.