### PR TITLE
Add pmt_online_monitor_configuration.fcl file with a new configuratio…

### DIFF
--- a/installations/sbn-fd/ICARUS_OnlineMonitor.fcl
+++ b/installations/sbn-fd/ICARUS_OnlineMonitor.fcl
@@ -1,35 +1,9 @@
 #include "redis_connection.fcl"
-#include "opticaldetectormodules.fcl"
 #include "stage0_icarus_defs.fcl"
+#include "pmt_online_monitor_configuration.fcl"
 
 #analysis configuration pieces
 BEGIN_PROLOG
-
-icarus_opreco_pedestal_rmsslider: @local::standard_algo_pedestal_ub
-icarus_opreco_pedestal_rmsslider.BeamGateSamples:   1
-icarus_opreco_pedestal_rmsslider.SampleSize:        30
-icarus_opreco_pedestal_rmsslider.Threshold:         4.0
-icarus_opreco_pedestal_rmsslider.Verbose:           false
-icarus_opreco_pedestal_rmsslider.NWaveformsToFile:  0
-icarus_opreco_pedestal_rmsslider.MaxSigma:          4.0
-icarus_opreco_pedestal_rmsslider.PedRangeMax:       16000
-icarus_opreco_pedestal_rmsslider.PedRangeMin:       13000
-icarus_opreco_pedestal_rmsslider.NumPreSample:      10
-icarus_opreco_pedestal_rmsslider.NumPostSample:     20
-
-icarus_opreco_hit_slidingwindow: @local::standard_algo_slidingwindow
-icarus_opreco_hit_slidingwindow.PositivePolarity:    false
-icarus_opreco_hit_slidingwindow.NumPreSample:        5
-icarus_opreco_hit_slidingwindow.NumPostSample:       10
-icarus_opreco_hit_slidingwindow.ADCThreshold:        10 # ADC threshold (absolute) above pedestal mean to fire a pulse
-icarus_opreco_hit_slidingwindow.NSigmaThreshold:     3 # ADC threshold (N*pedestal sigma) above pedestal mean to fire a pulse
-icarus_opreco_hit_slidingwindow.TailADCThreshold:    6 # ADC threshold (absolute) below which next pulse is allowed to fire
-icarus_opreco_hit_slidingwindow.TailNSigmaThreshold: 2 # ADC threshold (N*pedestal sigma) below which next pulse is allowed to fire
-icarus_opreco_hit_slidingwindow.EndADCThreshold:     3 # ADC threshold (absolute) at which the pulse ends
-icarus_opreco_hit_slidingwindow.EndNSigmaThreshold:  1 # ADC threshold (N*pedetal sigma) at which the pulse ends
-icarus_opreco_hit_slidingwindow.MinPulseWidth:       5 # The width of a pulse needs to be equal or larger than this to be recorded
-icarus_opreco_hit_slidingwindow.Verbosity:           false
-
 
 tpclabels_daq: ["daq:PHYSCRATEDATATPCEE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCWW"]
 tpclabels_DecoderRaw: ["daqTPC:PHYSCRATEDATATPCEERAW","daqTPC:PHYSCRATEDATATPCEWRAW","daqTPC:PHYSCRATEDATATPCWERAW","daqTPC:PHYSCRATEDATATPCWWRAW"]
@@ -77,6 +51,7 @@ analysis_config: {
   // Change tick period to be 0.4 for ICARUS
   tick_period: 0.4
 }
+
 END_PROLOG
 
 
@@ -270,8 +245,8 @@ physics.analyzers:
       OpDetWaveformLabel: "daqPMT"
 
       reco_man:      @local::standard_preco_manager
-      HitAlgoConfig: @local::icarus_opreco_hit_slidingwindow
-      PedAlgoConfig: @local::icarus_opreco_pedestal_rmsslider 
+      HitAlgoConfig: @local::icarus_pmt_om_ophit_algo
+      PedAlgoConfig: @local::icarus_pmt_om_pedestal_algo 
 
 
       PMTMetricConfig: {
@@ -279,7 +254,7 @@ physics.analyzers:
         hostname: "icarus-db01.fnal.gov"
     
         groups: {
-            PMT: [ [0, 380] ]
+            PMT: [ [0, 384] ]
         }
 
         streams: ["archiving"]
@@ -289,7 +264,7 @@ physics.analyzers:
           rms: {
             units: ADC
             title: "PMT channel %(instance)s rms"
-            display_range: [0., 50.]
+            display_range: [0., 20.]
           }
 
           baseline: {

--- a/sbndqm/dqmAnalysis/PMT/fcl/pmt_online_monitor.fcl
+++ b/sbndqm/dqmAnalysis/PMT/fcl/pmt_online_monitor.fcl
@@ -1,34 +1,7 @@
-#include "simple_channel_info.fcl"
 #include "redis_connection.fcl"
-#include "opticaldetectormodules.fcl"
+#include "pmt_online_monitor_configuration.fcl"
 
-
-
-icarus_opreco_pedestal_rmsslider: @local::standard_algo_pedestal_ub
-icarus_opreco_pedestal_rmsslider.BeamGateSamples:   1
-icarus_opreco_pedestal_rmsslider.SampleSize:        30
-icarus_opreco_pedestal_rmsslider.Threshold:         4.0
-icarus_opreco_pedestal_rmsslider.Verbose:           false
-icarus_opreco_pedestal_rmsslider.NWaveformsToFile:  0
-icarus_opreco_pedestal_rmsslider.MaxSigma:          4.0
-icarus_opreco_pedestal_rmsslider.PedRangeMax:       16000
-icarus_opreco_pedestal_rmsslider.PedRangeMin:       13000
-icarus_opreco_pedestal_rmsslider.NumPreSample:      10
-icarus_opreco_pedestal_rmsslider.NumPostSample:     20
-
-icarus_opreco_hit_slidingwindow: @local::standard_algo_slidingwindow
-icarus_opreco_hit_slidingwindow.PositivePolarity:    false
-icarus_opreco_hit_slidingwindow.NumPreSample:        5
-icarus_opreco_hit_slidingwindow.NumPostSample:       10
-icarus_opreco_hit_slidingwindow.ADCThreshold:        10 # ADC threshold (absolute) above pedestal mean to fire a pulse
-icarus_opreco_hit_slidingwindow.NSigmaThreshold:     3 # ADC threshold (N*pedestal sigma) above pedestal mean to fire a pulse
-icarus_opreco_hit_slidingwindow.TailADCThreshold:    6 # ADC threshold (absolute) below which next pulse is allowed to fire
-icarus_opreco_hit_slidingwindow.TailNSigmaThreshold: 2 # ADC threshold (N*pedestal sigma) below which next pulse is allowed to fire
-icarus_opreco_hit_slidingwindow.EndADCThreshold:     3 # ADC threshold (absolute) at which the pulse ends
-icarus_opreco_hit_slidingwindow.EndNSigmaThreshold:  1 # ADC threshold (N*pedetal sigma) at which the pulse ends
-icarus_opreco_hit_slidingwindow.MinPulseWidth:       5 # The width of a pulse needs to be equal or larger than this to be recorded
-icarus_opreco_hit_slidingwindow.Verbosity:           false
-
+process_name: ICARUSPMTANALYSIS
 
 physics: {
   
@@ -51,8 +24,8 @@ physics: {
       OpDetWaveformLabel: "daqPMT"
 
       reco_man:      @local::standard_preco_manager
-      HitAlgoConfig: @local::icarus_opreco_hit_slidingwindow
-      PedAlgoConfig: @local::icarus_opreco_pedestal_rmsslider 
+      HitAlgoConfig: @local::icarus_pmt_om_ophit_algo
+      PedAlgoConfig: @local::icarus_pmt_om_pedestal_algo
 
 
       PMTMetricConfig: {
@@ -94,7 +67,7 @@ physics: {
   my_producer_modules: [ daqPMT ]
   trigger_paths: [ my_producer_modules ]
   
-  ana: [ pmtAnalysis ]
+  ana: [ pmtAnalysis ] 
   end_paths: [ ana ]
 
 }
@@ -125,5 +98,3 @@ source:
   fileNames: ["/data1/sbndaq_dl01_r001248_sr01_20190702T192250_22_dl2.root"]
 }
 
-
-process_name: ICARUSPMTANALYSIS

--- a/sbndqm/dqmAnalysis/PMT/fcl/pmt_online_monitor_configuration.fcl
+++ b/sbndqm/dqmAnalysis/PMT/fcl/pmt_online_monitor_configuration.fcl
@@ -1,0 +1,38 @@
+#include "opticaldetectormodules.fcl"
+
+BEGIN_PROLOG
+#
+# Dirty solution: should depend on the configuration defined in icaruscode icarus_ophitfinder.fcl 
+# Currently we are fishing the configuration from larreco and setting it to the same values of icaruscode v09_43_00
+#
+icarus_pmt_om_pedestal_algo: @local::standard_algo_pedestal_ub
+icarus_pmt_om_pedestal_algo.BeamGateSamples:   1
+icarus_pmt_om_pedestal_algo.SampleSize:        20
+icarus_pmt_om_pedestal_algo.Threshold:         4.0
+icarus_pmt_om_pedestal_algo.Verbose:           false
+icarus_pmt_om_pedestal_algo.NWaveformsToFile:  0
+icarus_pmt_om_pedestal_algo.MaxSigma:          4.0
+icarus_pmt_om_pedestal_algo.PedRangeMax:       18000  # Very high constrain. Let the OM find the right one 
+icarus_pmt_om_pedestal_algo.PedRangeMin:       10000  # Very low constrain. Let the OM find the right one
+icarus_pmt_om_pedestal_algo.NumPreSample:      10
+icarus_pmt_om_pedestal_algo.NumPostSample:     20
+#
+# Dirty solution: should depend on the configuration defined in icaruscode icarus_ophitfinder.fcl
+# Currently we are fishing the configuration from larreco and setting it to the same values of icaruscode v09_43_00
+#
+icarus_pmt_om_ophit_algo: @local::standard_algo_slidingwindow
+icarus_pmt_om_ophit_algo.PositivePolarity:    false
+icarus_pmt_om_ophit_algo.NumPreSample:        5
+icarus_pmt_om_ophit_algo.NumPostSample:       10
+icarus_pmt_om_ophit_algo.ADCThreshold:        10 
+icarus_pmt_om_ophit_algo.NSigmaThreshold:     3 
+icarus_pmt_om_ophit_algo.TailADCThreshold:    6 
+icarus_pmt_om_ophit_algo.TailNSigmaThreshold: 2 
+icarus_pmt_om_ophit_algo.EndADCThreshold:     2 
+icarus_pmt_om_ophit_algo.EndNSigmaThreshold:  1 
+icarus_pmt_om_ophit_algo.MinPulseWidth:       5 
+icarus_pmt_om_ophit_algo.Verbosity:           false
+
+
+END_PROLOG
+


### PR DESCRIPTION
This pull request fixes the configuration of the PMT pedestal evaluation used for the Online Monitor data quality metrics. 
The configuration currently is saved inside `dqmAnalysis/PMT/fcl/pmt_online_monitor_configuration.fcl` and it is a copy of the configuration currently in use for `icaruscode v09_42_00` ( see [icarus_ophitfinder.fcl](https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl) ).  

Notes for the reviewer of this PR: 

1. The reference to the configuration in `icaruscode` is not dynamic. This should be eventually implemented, but the configuration in `icaruscode` also needs to be defined differently to better be referenced by other files.  This can be done on a second iteration. For now the evaluation of the Pedestal and its RMS is sufficiently accurate to spot the most relevant data quality issues.  
2. This branch is up-to-date with the shifter DQM version ( `DQM_DevAreas/DQM_08Mar22`)  