### PR TITLE
SBND PMT workflow

### DIFF
--- a/sbndqm/dqmAnalysis/PMT/CMakeLists.txt
+++ b/sbndqm/dqmAnalysis/PMT/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(ICARUS)
 add_subdirectory(SBND)
-
+add_subdirectory(fcl)

--- a/sbndqm/dqmAnalysis/PMT/fcl/CMakeLists.txt
+++ b/sbndqm/dqmAnalysis/PMT/fcl/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()


### PR DESCRIPTION
This PR includes the SBND workflow for the PMT.
- Main change:
  - Decoder for SBND and splitting the workflows betwen ICARUS/SBND (by @VCLanNguyen, details in [doc-30300])(https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=30300)
- Other updates
  - Added FFTs for the PMTs
  - Working fhicl configuration (test results in [doc-31775](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=31775) slides 17-28)

